### PR TITLE
Test incremental new

### DIFF
--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -61,6 +61,7 @@ jobs:
           maven-version: ${{ matrix.maven-version }}
           cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
       - name: Temp workaround to test incremental build
+        uses: actions/github-script@v3
         with:
           script: |
             git remote add gitgabrio https://github.com/gitgabrio/drools.git

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -93,4 +93,10 @@ jobs:
           name: build-compare_${{ matrix.job_name }}_${{ matrix.os }}
           path: |
             **/*.buildcompare
-            **/*.buildinfo    
+            **/*.buildinfo
+      - name: Upload Incremental Build
+        uses: actions/upload-artifact@v7
+        if: ${{ always() }}
+        with:
+          name: incremental-build_${{ matrix.job_name }}_${{ matrix.os }}
+          path: '**/incremental_build.log'

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -60,6 +60,11 @@ jobs:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
           cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+      - name: Temp workaround to test incremental build
+        with:
+          script: |
+            git remote add gitgabrio https://github.com/gitgabrio/drools.git
+            git fetch gitgabrio
       - name: Build Chain
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         env:

--- a/.github/workflows/pr-drools.yml
+++ b/.github/workflows/pr-drools.yml
@@ -60,12 +60,6 @@ jobs:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
           cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
-      - name: Temp workaround to test incremental build
-        uses: actions/github-script@v3
-        with:
-          script: |
-            git remote add gitgabrio https://github.com/gitgabrio/drools.git
-            git fetch gitgabrio
       - name: Build Chain
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         env:

--- a/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
+++ b/kie-dmn/kie-dmn-core/src/main/java/org/kie/dmn/core/impl/AfterEvaluateAllEventImpl.java
@@ -20,8 +20,12 @@ package org.kie.dmn.core.impl;
 
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.event.AfterEvaluateAllEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AfterEvaluateAllEventImpl implements AfterEvaluateAllEvent {
+
+    private static final Logger logger = LoggerFactory.getLogger(AfterEvaluateAllEventImpl.class);
 
     private String modelNamespace;
     private String modelName;
@@ -50,6 +54,7 @@ public class AfterEvaluateAllEventImpl implements AfterEvaluateAllEvent {
 
     @Override
     public String toString() {
+        logger.warn("toString() not implemented for " + this.getClass().getName() + ", returning a placeholder string instead.");
         return "AfterEvaluateAllEventImpl{ modelNamespace=" + modelNamespace + ", modelName=" + modelName + "}";
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
         <configuration>
           <skipTestsForUpstreamModules>true</skipTestsForUpstreamModules>
           <forceBuildModules>drools-verifier-drl</forceBuildModules>
+          <logImpactedTo>${pom.build.directory}/incremental_build.log</logImpactedTo>
           <!-- ... -->
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
     <!-- incremental build -->
-    <gib.referenceBranch>refs/remotes/gitgabrio/test_incremental</gib.referenceBranch>
+    <gib.referenceBranch>refs/remotes/gitgabrio/drools/test_incremental</gib.referenceBranch>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
     <!-- incremental build -->
-    <gib.referenceBranch>refs/remotes/gitgabrio/drools/test_incremental</gib.referenceBranch>
+    <gib.referenceBranch>refs/remotes/gitgabrio/test_incremental</gib.referenceBranch>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
     <!-- incremental build -->
-    <gib.referenceBranch>refs/remotes/origin/main</gib.referenceBranch>
+    <gib.referenceBranch>refs/remotes/gitgabrio/test_incremental</gib.referenceBranch>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
     <!-- incremental build -->
-    <gib.referenceBranch>refs/remotes/gitgabrio/test_incremental</gib.referenceBranch>
+    <gib.referenceBranch>refs/remotes/test_incremental</gib.referenceBranch>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -116,18 +116,10 @@
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
     <!-- incremental build -->
-    <gib.referenceBranch>refs/heads/main</gib.referenceBranch>
+    <gib.referenceBranch>refs/remotes/origin/main</gib.referenceBranch>
   </properties>
 
   <build>
-    <extensions>
-      <extension>
-        <!-- incremental build -->
-        <groupId>io.github.gitflow-incremental-builder</groupId>
-        <artifactId>gitflow-incremental-builder</artifactId>
-        <version>4.6.0</version>
-      </extension>
-    </extensions>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -140,6 +132,20 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <!-- incremental build -->
+        <groupId>io.github.gitflow-incremental-builder</groupId>
+        <artifactId>gitflow-incremental-builder</artifactId>
+        <version>4.6.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <skipTestsForUpstreamModules>true</skipTestsForUpstreamModules>
+          <forceBuildModules>drools-verifier-drl</forceBuildModules>
+          <!-- ... -->
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -115,9 +115,19 @@
   <properties>
     <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
     <version.maven.artifact.plugin>3.4.1</version.maven.artifact.plugin>
+    <!-- incremental build -->
+    <gib.referenceBranch>refs/heads/main</gib.referenceBranch>
   </properties>
 
   <build>
+    <extensions>
+      <extension>
+        <!-- incremental build -->
+        <groupId>io.github.gitflow-incremental-builder</groupId>
+        <artifactId>gitflow-incremental-builder</artifactId>
+        <version>4.6.0</version>
+      </extension>
+    </extensions>
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
  -->

**Thank you for submitting this pull request**

**NOTE!:** Double-check the target branch for this PR.
The default is `main` so it will target Drools 8 / Kogito.

**Ports** If a forward-port or a backport is needed, paste the forward port PR here

* [link](https://www.example.com)

**Issue**: _(please edit the GitHub Issues link if it exists)_

* [link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request and downstream checks</b>  
  - Push a new commit to the PR. An empty commit would be enough.

- for a <b>full downstream build</b>
  - for <b>github actions</b> job: add the label `run_fdb`

- for <b>Jenkins PR check only</b>
  - If you are an ASF committer for KIE podling, login to Jenkins (https://ci-builds.apache.org/job/KIE/job/drools/), go to the specific PR job, and click on `Build Now` button.
</details>
